### PR TITLE
Align sellers middleware config with prod stage

### DIFF
--- a/src/services/leads/constants.ts
+++ b/src/services/leads/constants.ts
@@ -5,10 +5,10 @@ export const COLOMBIA_LEAD_COUNTRY = 'CO' as const
 export const SELLERS_STRATEGY_HELP_TO_SELL = 'help_to_sell' as const
 
 export const GEOREFERENCE_BASE_URL =
-  'https://apiv2.llavero.co/web-global-api-georeferencing/v1.0/georeference'
+  'https://apiv2.habi.co/web-global-api-georeferencing/v1.0/georeference'
 
 export const DEFAULT_MIDDLEWARE_URL =
-  'https://t7ln416bll.execute-api.us-east-2.amazonaws.com/dev/post_middleware'
+  'https://8eqyvzr6u9.execute-api.us-east-2.amazonaws.com/prod/post_middleware'
 
 /** Identificadores de origen para el body de `post_middleware` (Ayudaventas). */
 export const SELLERS_MIDDLEWARE_SOURCE_ID = 3 as const

--- a/src/services/leads/env.ts
+++ b/src/services/leads/env.ts
@@ -7,11 +7,11 @@ export function readEnv(key: string): string {
   }
   switch (key) {
     case 'VITE_GEOREFERENCE_API_KEY':
-      return 'bNvse3hoUWaATmKopmWXs3a8ifHCPDSK6qzMjpO1'
+      return 'NNKqq91UqB7mUraiwkmgm2b53FOSzeh14wDYPqvQ'
     case 'VITE_SELLERS_MIDDLEWARE_API_KEY':
-      return 'ZIsF5E6vCD5W3i8fu4cxGHeHUQXgBLT3aI1drg26'
+      return 'TN30vMr7Eg5ks2cbLzBtz3oAOvP7sD0HaYbm5QPS'
     case 'VITE_SELLERS_MIDDLEWARE_URL':
-      return 'https://t7ln416bll.execute-api.us-east-2.amazonaws.com/dev/post_middleware'
+      return 'https://8eqyvzr6u9.execute-api.us-east-2.amazonaws.com/prod/post_middleware'
     case 'VITE_ENABLE_SELLERS_MIDDLEWARE_CO':
       return 'true'
     default:

--- a/tests/services/leads/env.test.ts
+++ b/tests/services/leads/env.test.ts
@@ -12,7 +12,7 @@ describe('readEnv', () => {
   it('should resolve known VITE_* keys via switch when dynamic lookup is empty', () => {
     const prev = process.env.VITE_SELLERS_MIDDLEWARE_API_KEY
     delete process.env.VITE_SELLERS_MIDDLEWARE_API_KEY
-    expect(readEnv('VITE_SELLERS_MIDDLEWARE_API_KEY')).toBe('ZIsF5E6vCD5W3i8fu4cxGHeHUQXgBLT3aI1drg26')
+    expect(readEnv('VITE_SELLERS_MIDDLEWARE_API_KEY')).toBe('TN30vMr7Eg5ks2cbLzBtz3oAOvP7sD0HaYbm5QPS')
     process.env.VITE_SELLERS_MIDDLEWARE_API_KEY = 'k-from-switch'
     expect(readEnv('VITE_SELLERS_MIDDLEWARE_API_KEY')).toBe('k-from-switch')
     if (prev === undefined) {
@@ -39,7 +39,7 @@ describe('readEnv', () => {
     const prev = process.env.VITE_SELLERS_MIDDLEWARE_URL
     delete process.env.VITE_SELLERS_MIDDLEWARE_URL
     expect(readEnv('VITE_SELLERS_MIDDLEWARE_URL')).toBe(
-      'https://t7ln416bll.execute-api.us-east-2.amazonaws.com/dev/post_middleware'
+      'https://8eqyvzr6u9.execute-api.us-east-2.amazonaws.com/prod/post_middleware'
     )
     if (prev !== undefined) process.env.VITE_SELLERS_MIDDLEWARE_URL = prev
   })

--- a/tests/services/leads/submitColombiaLead.test.ts
+++ b/tests/services/leads/submitColombiaLead.test.ts
@@ -100,7 +100,7 @@ describe('submitColombiaLeadThroughMiddleware', () => {
     const readEnvSpy = jest.spyOn(envModule, 'readEnv').mockImplementation((key: string) => {
       if (key === 'VITE_GEOREFERENCE_API_KEY' || key === 'VITE_SELLERS_MIDDLEWARE_API_KEY') return ''
       if (key === 'VITE_SELLERS_MIDDLEWARE_URL') {
-        return 'https://t7ln416bll.execute-api.us-east-2.amazonaws.com/dev/post_middleware'
+        return 'https://8eqyvzr6u9.execute-api.us-east-2.amazonaws.com/prod/post_middleware'
       }
       return ''
     })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig(({ mode }) => {
       'process.env.VITE_SELLERS_MIDDLEWARE_API_KEY': JSON.stringify(env.VITE_SELLERS_MIDDLEWARE_API_KEY ?? ''),
       'process.env.VITE_SELLERS_MIDDLEWARE_URL': JSON.stringify(
         env.VITE_SELLERS_MIDDLEWARE_URL ??
-          'https://t7ln416bll.execute-api.us-east-2.amazonaws.com/dev/post_middleware'
+          'https://8eqyvzr6u9.execute-api.us-east-2.amazonaws.com/prod/post_middleware'
       ),
       'process.env.VITE_ENABLE_SELLERS_MIDDLEWARE_CO': JSON.stringify(env.VITE_ENABLE_SELLERS_MIDDLEWARE_CO ?? ''),
     },


### PR DESCRIPTION
## Descripción
Alinea la URL y API key del middleware de sellers con el stage `prod`, manteniendo consistencia entre runtime, fallback de Vite y unit tests.

## Contexto
**Ticket:** #3
Tras el merge del PR #4, la decisión de negocio fue usar valores hardcodeados apuntando a `prod`. Este PR corrige los lugares que aún quedaban apuntando al stage `dev`.

## Detalles Técnicos
- `src/services/leads/env.ts`: actualiza `VITE_SELLERS_MIDDLEWARE_API_KEY` y `VITE_SELLERS_MIDDLEWARE_URL` a valores de `prod`.
- `src/services/leads/constants.ts`: `DEFAULT_MIDDLEWARE_URL` apuntando a `prod`.
- `vite.config.ts`: fallback de `VITE_SELLERS_MIDDLEWARE_URL` alineado a `prod`.
- Tests: `env.test.ts` y `submitColombiaLead.test.ts` ajustados a los nuevos valores.

## Test plan
- [x] `npx jest --passWithNoTests` — 33/33 OK

Related to #3

Made with [Cursor](https://cursor.com)